### PR TITLE
Install curl and netcat during vagrant image setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,8 @@ echo "Installing system tools and docker..."
 # TODO Currently (v0.7.3) Kubernetes only works with etcd 0.4.6 - later
 # remove specific etcd version from yum install command.
 yum -y install yum-fastestmirror git mercurial subversion docker-io etcd-0.4.6-6.fc20
+# Packages useful for testing/interacting with containers.
+yum -y install curl nc
 # Docker setup.
 systemctl start docker
 systemctl enable docker

--- a/setup.sh
+++ b/setup.sh
@@ -5,12 +5,11 @@ echo "Setting up VM..."
 
 
 echo "Installing system tools and docker..."
-# Source control tools are so go get works properly.
+# Packages useful for testing/interacting with containers and
+# source control tools are so go get works properly.
 # TODO Currently (v0.7.3) Kubernetes only works with etcd 0.4.6 - later
 # remove specific etcd version from yum install command.
-yum -y install yum-fastestmirror git mercurial subversion docker-io etcd-0.4.6-6.fc20
-# Packages useful for testing/interacting with containers.
-yum -y install curl nc
+yum -y install yum-fastestmirror git mercurial subversion docker-io etcd-0.4.6-6.fc20 curl nc
 # Docker setup.
 systemctl start docker
 systemctl enable docker


### PR DESCRIPTION
Interacting with docker containers and kubernetes itself is
a lot easier if curl and netcat are already around.