### PR TITLE
Modifications to VagrantFile and the provisioning script

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,7 +48,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |c|
     end
 
     if $mount_users_dir
-      config.vm.synced_folder $home, $home, id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      # config.vm.synced_folder $home, $home, id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
+      config.vm.synced_folder $home, $home, id: "core"
     end
 
     config.vm.provider :virtualbox do |vb|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,14 +37,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |c|
   c.vm.define vm_name = "k8s-env" do |config|
     config.vm.hostname = vm_name
 
-    config.vm.box = "geerlingguy/centos7"
+    config.vm.box = "bento/centos-7.2"
 
-    # ip = "10.0.2.15"
-    # config.vm.network "private_network", ip: "10.1.2.3"
-    # TODO: For some reason the port assignment does not work.
-    # Use dhcp at this time.
-    config.vm.network "private_network", type: "dhcp"
-
+    ip = "10.1.2.3"
+    # config.vm.network "private_network", type: "dhcp"
+    config.vm.network "private_network", ip: ip
 
     config.vm.boot_timeout = 3000
 
@@ -62,6 +59,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |c|
       vb.cpus = $vb_cpus
     end
 
-    config.vm.provision "shell", inline: "HOST_GOPATH=#{$gopath} /vagrant/setup.sh"
+    config.vm.provision "shell", inline: "HOST_GOPATH=#{$gopath} GUEST_IP=#{ip} /vagrant/setup.sh"
   end
 end
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,16 +30,21 @@ end
 if $gopath.empty?
   abort("GOPATH env var must be set (or create a config.rb to specify it manually).\n")
 end
+# TODO: We should also add here a check that the GOPATH variable has only
+# one path. In other words it does not contain any other path delimiters.
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |c|
   c.vm.define vm_name = "k8s-env" do |config|
     config.vm.hostname = vm_name
 
     config.vm.box = "geerlingguy/centos7"
-    #config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.2_chef-provisionerless.box"
 
-    ip = "10.1.2.3"
-    config.vm.network :private_network, ip: ip
+    # ip = "10.0.2.15"
+    # config.vm.network "private_network", ip: "10.1.2.3"
+    # TODO: For some reason the port assignment does not work.
+    # Use dhcp at this time.
+    config.vm.network "private_network", type: "dhcp"
+
 
     config.vm.boot_timeout = 3000
 
@@ -48,8 +53,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |c|
     end
 
     if $mount_users_dir
-      # config.vm.synced_folder $home, $home, id: "core", :nfs => true, :mount_options => ['nolock,vers=3,udp']
-      config.vm.synced_folder $home, $home, id: "core"
+      config.vm.synced_folder $home, $home, type: "nfs"
     end
 
     config.vm.provider :virtualbox do |vb|
@@ -58,6 +62,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |c|
       vb.cpus = $vb_cpus
     end
 
-    config.vm.provision "shell", inline: "GOPATH=#{$gopath} /vagrant/setup.sh"
+    config.vm.provision "shell", inline: "HOST_GOPATH=#{$gopath} /vagrant/setup.sh"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |c|
     config.vm.box = "bento/centos-7.2"
 
     ip = "10.1.2.3"
-    # config.vm.network "private_network", type: "dhcp"
     config.vm.network "private_network", ip: ip
 
     config.vm.boot_timeout = 3000

--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,13 @@
 
 
 
+function installSystemTools() {
+   echo "Installing system tools..."
+   yum -y install epel-release
+   # Packages useful for testing/interacting with containers and
+   # source control tools are so go get works properly.
+   yum -y install yum-fastestmirror git mercurial subversion curl nc gcc
+}
 
 # Add a repository to yum so that we can download
 # supported version of docker.
@@ -59,13 +66,7 @@ set -x
 
 echo "Setting up VM..."
 
-
-echo "Installing system tools..."
-yum -y install epel-release
-# Packages useful for testing/interacting with containers and
-# source control tools are so go get works properly.
-yum -y install yum-fastestmirror git mercurial subversion curl nc gcc
-
+installSystemTools
 
 installDocker
 startDocker

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #/!/bin/bash
 
 # A provisioning script for the created Vagrant vm.
-# This script is referred from the Vafrant file and it is executed during the
+# This script is referred from the Vagrant file and it is executed during the
 # provisioning phase of starting a new vm.
 # Note: For this script to work there should be only one path in GOPATH env.
 # Everything in this file is run as root on the VM.

--- a/setup.sh
+++ b/setup.sh
@@ -159,6 +159,7 @@ function installGoPackages() {
 # automatically at every login
 function writeProfileFile() {
    local guestGopath=$1
+   local guestIp=$2
 echo "Creating /etc/profile.d/kubernetes.sh to set GOPATH, KUBERNETES_PROVIDER and other config..."
 cat >/etc/profile.d/kubernetes.sh <<EOL
 # Golang setup.
@@ -168,13 +169,11 @@ export PATH=\$PATH:${guestGopath}/bin
 export DOCKER_HOST=tcp://127.0.0.1:2375
 # So you can start using cluster/kubecfg.sh right away.
 export KUBERNETES_PROVIDER=local
-# Run apiserver on 10.1.2.3 (instead of 127.0.0.1) so you can access
+# Run apiserver on guestIP (instead of 127.0.0.1) so you can access
 # apiserver from your OS X host machine.
-# FixMe: Somehow I would not make the network interface setup work correctly
-# So the following two settings would not work as is.
-# export API_HOST=10.1.2.3
+export API_HOST=${guestIp}
 # So you can access apiserver from kubectl in the VM.
-# export KUBERNETES_MASTER=\${API_HOST}:8080
+export KUBERNETES_MASTER=\${API_HOST}:8080
 
 # For convenience.
 alias k="cd \$GOPATH/src/k8s.io/kubernetes"
@@ -208,7 +207,7 @@ setupGopath "${HOST_GOPATH}" "${GUEST_GOPATH}"
 export GOPATH=${GUEST_GOPATH}
 
 installGoPackages
-writeProfileFile  "${GUEST_GOPATH}"
+writeProfileFile  "${GUEST_GOPATH}" "${GUEST_IP}"
 
 
 # For some reason /etc/hosts does not alias localhost to 127.0.0.1.

--- a/setup.sh
+++ b/setup.sh
@@ -61,6 +61,21 @@ function startDocker() {
    echo "Docker daemon started."
 }
 
+# Install go at the given version. The desired version string is passed as the
+# first paramter of the function.
+# Example usage:
+# installGo "1.6.2"
+function installGo() {
+   local GOVERSION=$1
+   local GOBINARY=go${GOVERSION}.linux-amd64.tar.gz
+   echo "Installing go ${GOVERSION}..."
+   wget -q https://storage.googleapis.com/golang/$GOBINARY
+   tar -C /usr/local/ -xzf $GOBINARY
+   ln -sf /usr/local/go/bin/* /usr/bin/
+   rm -f $GOBINARY
+   echo "Complete."
+}
+
 set -e
 set -x
 
@@ -71,15 +86,7 @@ installSystemTools
 installDocker
 startDocker
 
-
-GOVERSION=1.6.2
-GOBINARY=go${GOVERSION}.linux-amd64.tar.gz
-echo "Installing go ${GOVERSION}..."
-wget -q https://storage.googleapis.com/golang/$GOBINARY
-tar -C /usr/local/ -xzf $GOBINARY
-ln -sf /usr/local/go/bin/* /usr/bin/
-rm -f $GOBINARY
-echo "Complete."
+installGo "1.6.2"
 
 
 #ETCDVERSION=v2.2.2

--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ function install_docker() {
 # Keep in mind that at this point this
 # overrides any existing options supplied by the RPM. This is overridden to
 # make sure docker is listening on all network interfaces.
-function setDockerDaemonOptions() {
+function set_docker_daemon_options() {
    echo "" > /etc/sysconfig/docker
    mkdir -p /etc/systemd/system/docker.service.d
    tee /etc/systemd/system/docker.service.d/docker.conf <<-'EOF'
@@ -54,7 +54,7 @@ EOF
 # configure_and_start_docker starts the docker service using systemctl
 function configure_and_start_docker() {
 
-   setDockerDaemonOptions
+   set_docker_daemon_options
 
    systemctl daemon-reload
    systemctl start docker
@@ -64,7 +64,7 @@ function configure_and_start_docker() {
 
 # Downloads the file with wget if it does not exist in the current directory.
 # The user passes the wget argument path to this function as the first parameter
-function maybe_download_file() {
+function ensure_file_is_downloaded() {
    local wgetArg=$1
    local fileName=$(basename "${wgetArg}")
    if [ -f "${fileName}" ]; then
@@ -88,7 +88,7 @@ function install_go() {
       local goVersion=$1
       local goBinary=go${goVersion}.linux-amd64.tar.gz
       echo "Installing go ${goVersion}..."
-      maybe_download_file  https://storage.googleapis.com/golang/$goBinary
+      ensure_file_is_downloaded  https://storage.googleapis.com/golang/$goBinary
       tar -C /usr/local/ -xzf $goBinary
       ln -sf /usr/local/go/bin/* /usr/bin/
       echo "Installed go ${goVersion}."
@@ -106,7 +106,7 @@ function install_etcd() {
       echo "Installing etcd ${etcdVersion}..."
       etcdName=etcd-${etcdVersion}-linux-amd64
       etcdBinary=${etcdName}.tar.gz
-      maybe_download_file https://github.com/coreos/etcd/releases/download/${etcdVersion}/${etcdBinary}
+      ensure_file_is_downloaded https://github.com/coreos/etcd/releases/download/${etcdVersion}/${etcdBinary}
       tar -C /usr/local/ -xzf ${etcdBinary}
       rm -rf  /usr/local/etcd
       mv -n /usr/local/${etcdName} /usr/local/etcd
@@ -121,7 +121,7 @@ function install_etcd() {
 # /Users directory tree in the host machine. The Vagrantfile sets up
 # the /Users directory as a synced_folder. So the HOST_GOPATH that is under
 # /Users will be visible in the Vagrant vm.
-function setupGopath() {
+function setup_gopath() {
    local hostGopath=$1
    local guestGopath=$2
    echo "Creating a GOPATH in ${guestGopath} local to the VM..."
@@ -211,7 +211,7 @@ install_etcd "v3.0.10"
 
 # HOST_GOPATH is passed by the VagrantFile looking at the Mac's environment.
 GUEST_GOPATH=/home/vagrant/gopath
-setupGopath "${HOST_GOPATH}" "${GUEST_GOPATH}"
+setup_gopath "${HOST_GOPATH}" "${GUEST_GOPATH}"
 # The rest of the script installed some gobinaries. So the GOPATH needs to be known
 # from this point on .
 export GOPATH=${GUEST_GOPATH}

--- a/setup.sh
+++ b/setup.sh
@@ -205,7 +205,7 @@ install_docker
 configure_and_start_docker
 
 # Get the go and etcd releases.
-install_go "1.7.1"
+install_go "1.6.3"
 # Latest kubernetes requires a recent version of etcd
 install_etcd "v3.0.10"
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,32 @@
 #/!/bin/bash
 
+# A provisioning script for the created Vagrant vm.
+# This script is referred from the Vafrant file and it is executed during the
+# provisioning phase of starting a new vm.
 # Everything in this file is run as root on the VM.
 
+
+
+
+# Add a repository to yum so that we can download
+# supported version of docker.
+function addDockerYumRepo() {
+   tee /etc/yum.repos.d/docker.repo <<-'EOF'
+[dockerrepo]
+name=Docker Repository
+baseurl=https://yum.dockerproject.org/repo/main/centos/7/
+enabled=1
+gpgcheck=1
+gpgkey=https://yum.dockerproject.org/gpg
+EOF
+}
+
+# Set up yum and install the supported version of docker
+function installDocker() {
+   addDockerYumRepo
+
+   yum -y install docker-engine-1.10.3
+}
 
 # Set docker daemon comand line options. We modify systemd configuration
 # for docker to start with our desired options.
@@ -41,17 +66,8 @@ yum -y install epel-release
 # source control tools are so go get works properly.
 yum -y install yum-fastestmirror git mercurial subversion curl nc gcc
 
-tee /etc/yum.repos.d/docker.repo <<-'EOF'
-[dockerrepo]
-name=Docker Repository
-baseurl=https://yum.dockerproject.org/repo/main/centos/7/
-enabled=1
-gpgcheck=1
-gpgkey=https://yum.dockerproject.org/gpg
-EOF
 
-yum -y install docker-engine-1.10.3
-
+installDocker
 startDocker
 
 

--- a/setup.sh
+++ b/setup.sh
@@ -20,6 +20,9 @@ EOF
 
 # startDocker starts the docker service using systemctl
 function startDocker() {
+
+   setDockerDaemonOptions
+
    systemctl daemon-reload
    systemctl start docker
    systemctl enable docker
@@ -49,22 +52,7 @@ EOF
 
 yum -y install docker-engine-1.10.3
 
-# Set docker daemon comand line options. Keep in mind that at this point this
-# overrides any existing options supplied by the RPM. This is overridden to
-# make sure docker is listening on all network interfaces.
-echo "" > /etc/sysconfig/docker
-mkdir /etc/systemd/system/docker.service.d
-tee /etc/systemd/system/docker.service.d/docker.conf <<-'EOF'
-[Service]
-ExecStart=
-ExecStart=/usr/bin/docker daemon --selinux-enabled -H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375
-EOF
-
-# # Start docker.
-# systemctl start docker
-# # Start docker on startup.
-# systemctl enable docker
-# echo "Complete."
+startDocker
 
 
 GOVERSION=1.6.2
@@ -149,5 +137,4 @@ export GOPATH=/home/vagrant/gopath
 sudo -u vagrant -E go get github.com/tools/godep && sudo -u vagrant -E go install github.com/tools/godep
 echo "Complete."
 
-startDocker
 echo "Setup complete."


### PR DESCRIPTION
With these changes we can use vagrant 1.8.6 and VirtualBox 5.1.6 together to run centos 7.2 vm's 

The vm compiles local-up-cluster and the API server is reachable from the os x host. 